### PR TITLE
Moved event loading to the initial calendar options.

### DIFF
--- a/yii2fullcalendar.php
+++ b/yii2fullcalendar.php
@@ -64,10 +64,11 @@ class yii2fullcalendar extends elWidget
     public $ajaxEvents = NULL;
     
     /**
-     * wheather the events will be "sticky" on pagination or not
+     * wheather the events will be "sticky" on pagination or not. Uncomment if you are loading events
+	 * separately from the initial options.
      * @var boolean
      */
-    public $stickyEvents = true;
+    //public $stickyEvents = true;
 
     /**
      * tell the calendar, if you like to render google calendar events within the view
@@ -189,16 +190,20 @@ class yii2fullcalendar extends elWidget
         $cleanOptions = $this->getClientOptions();
         $js[] = "jQuery('#$id').fullCalendar($cleanOptions);";
 
-        //lets check if we have an event for the calendar...
-        if(count($this->events)>0)
-        {
-            foreach($this->events AS $event)
-            {
-                $jsonEvent = Json::encode($event);
-                $isSticky = $this->stickyEvents;
-                $js[] = "jQuery('#$id').fullCalendar('renderEvent',$jsonEvent,$isSticky);";
-            }
-        }
+        /**
+		* Loads events separately from the calendar creation. Uncomment if you need this functionality.
+		*
+		* lets check if we have an event for the calendar...
+        * if(count($this->events)>0)
+        * {
+        *    foreach($this->events AS $event)
+        *    {
+        *        $jsonEvent = Json::encode($event);
+        *        $isSticky = $this->stickyEvents;
+        *        $js[] = "jQuery('#$id').fullCalendar('renderEvent',$jsonEvent,$isSticky);";
+        *    }
+        * }
+		*/
         
         $view->registerJs(implode("\n", $js),View::POS_READY);
     }
@@ -221,6 +226,11 @@ class yii2fullcalendar extends elWidget
         if ($this->eventAfterAllRender){
             $options['eventAfterAllRender'] = new JsExpression($this->eventAfterAllRender);
         }
+		//checks for events and loads them into the options. Comment out if loading separately.
+		if (count($this->events)>0)
+		{
+			$options['events'] = $this->events;
+		}
         $options = array_merge($options, $this->clientOptions);
         return Json::encode($options);
     }


### PR DESCRIPTION
The repeated events that were added previously were duplicating when changing months due to the way that the events were added. I have commented out adding events with the ```renderEvent``` as a separate process, and I have instead moved checking for events and adding them down in to ```getClientOptions()```.

This fixes the duplication issue, and all other events are still loading without issue.