### PR TITLE
Correct 'language' parameter in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you wanna use ajax loader, this could look like this:
 ```php
 <?= yii2fullcalendar\yii2fullcalendar::widget([
       'options' => [
-        'language' => 'de',
+        'lang' => 'de',
         //... more options to be defined here!
       ],
       'ajaxEvents' => Url::to(['/timetrack/default/jsoncalendar'])


### PR DESCRIPTION
There are differences between example provided on the project homepage and an actual parameter, used in plugin itself. We should use 'lang' instead of 'language'.