### PR TITLE
Enhancement for using yii2fullcalendar with pjax

### DIFF
--- a/yii2fullcalendar.php
+++ b/yii2fullcalendar.php
@@ -185,6 +185,11 @@ class yii2fullcalendar extends elWidget
         } else {
             $this->clientOptions['header'] = $this->header;
         }
+	
+	// clear existing calendar display before rendering new fullcalendar instance
+	// this step is important when using the fullcalendar widget with pjax
+	$js[] = "var loading_container = jQuery('#$id .fc-loading');"; // take backup of loading container
+	$js[] = "jQuery('#$id').empty().append(loading_container);"; // remove/empty the calendar container and append loading container bakup
 
         $cleanOptions = $this->getClientOptions();
         $js[] = "jQuery('#$id').fullCalendar($cleanOptions);";


### PR DESCRIPTION
When using the yii2fullcalendar widget with pjax, if the user clicks the browser back button to go back to a page/view with the fullcalendar widget, the fullcalendar javascript is fired again, and the calendar becomes rendered twice.  This enhancement to the yii2fullcalendar widget addresses this issue by clearing/emptying the calendar container before rendering a new instance of the calendar.  There is probably a better/cleaner way to address this issue, however this approach works and should work without negatively affecting other possible widget use cases.