### PR TITLE
Added Support for Non-Standard fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Quickstart Looks like this:
   $Event->id = 1;
   $Event->title = 'Testing';
   $Event->start = date('Y-m-d\TH:i:s\Z');
+  $event->nonstandard = [
+    'field1' => 'Something I want to be included in object #1',
+    'field2' => 'Something I want to be included in object #2',
+  ],
   $events[] = $Event;
 
   $Event = new \yii2fullcalendar\models\Event();
@@ -63,13 +67,13 @@ Quickstart Looks like this:
   $events[] = $Event;
 
   ?>
-  
+
   <?= \yii2fullcalendar\yii2fullcalendar::widget(array(
       'events'=> $events,
   ));
 ```
 
-Note, that this will only view the events without any detailed view or option to add a new event.. etc.
+Note, that this will only view the events without any detailed view or option to add a new event.. etc. You can add non-standard fields via the non-standard fields array, for which you can pass any key/value pair. 
 
 AJAX Usage
 ==========

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ And ensure, that you have the following plugin installed global:
 Changelog
 ---------
 
+19-01-2017 Updated to include non-standard fields
 29-11-2014 Updated to latest 2.2.3 Version of the library
 
 Usage
@@ -73,7 +74,14 @@ Quickstart Looks like this:
   ));
 ```
 
-Note, that this will only view the events without any detailed view or option to add a new event.. etc. You can add non-standard fields via the non-standard fields array, for which you can pass any key/value pair. 
+Note, that this will only view the events without any detailed view or option to add a new event.. etc.
+
+Non-Standard fields
+===================
+
+You can add non-standard fields via the non-standard fields array, for which you can pass any key/value pair, as described in the [Event Fields](https://fullcalendar.io/docs/event_data/Event_Object/) documentation.
+
+So, using the Quick Start example above, you can read `field1` and `fields2` in your JavaScript using notation similar to `event.nonstandard.field1` and `event.nonstandard.field2`.
 
 AJAX Usage
 ==========

--- a/models/Event.php
+++ b/models/Event.php
@@ -11,7 +11,7 @@ class Event extends Model
    * Detailed description off all fields can be found here
    * @url http://arshaw.com/fullcalendar/docs/event_data/Event_Object/
    */
-  
+
   /**
    * the id of the shown event
    * @var integer
@@ -23,7 +23,7 @@ class Event extends Model
    * @var string
    */
   public $title;
-  
+
   /**
    * The description text for an event
    * @var string
@@ -38,14 +38,14 @@ class Event extends Model
    * @var boolean
    */
   public $allDay;
-  
+
   /**
    * The date/time an event begins. Required.
    * A Moment-ish input, like an ISO8601 string. Throughout the API this will become a real Moment object.
    * @var datetime
    */
   public $start;
-  
+
   /**
    * The exclusive date/time an event ends. Optional.
    * A Moment-ish input, like an ISO8601 string. Throughout the API this will become a real Moment object.
@@ -53,7 +53,7 @@ class Event extends Model
    * @var datetime
    */
   public $end;
-  
+
   /**
    * The range of dates that an event is to show on the calendar.
    * Used with a function to check the dates in eventRender against the range and only render
@@ -67,77 +67,88 @@ class Event extends Model
    * @var array
    */
    public $dow;
-  
+
   /**
    * A URL that will be visited when this event is clicked by the user. For more information on controlling this behavior, see the eventClick callback.
    * @var [type]
    */
   public $url;
-  
+
   /**
    * A CSS class (or array of classes) that will be attached to this event's element.
    * @var [type]
    */
   public $className;
-  
+
   /**
    * Overrides the master editable option for this single event.
    * @var boolean
    */
   public $editable;
-  
+
   /**
    * Overrides the master eventStartEditable option for this single event.
    * @var [type]
    */
   public $startEditable;
-  
+
   /**
    * Overrides the master eventDurationEditable option for this single event.
    * @var [type]
    */
   public $durationEditable;
-  
+
   /**
    * A reference to the event source that this event came from.
    * @var [type]
    */
   public $source;
-  
+
   /**
    * Sets an event's background and border color just like the calendar-wide eventColor option.
    * @var [type]
    */
   public $color;
-  
+
   /**
    * Sets an event's background color just like the calendar-wide eventBackgroundColor option.
    * @var [type]
    */
   public $backgroundColor;
-  
+
   /**
    * Sets an event's border color just like the the calendar-wide eventBorderColor option.
    * @var [type]
    */
   public $borderColor;
-  
+
   /**
    * Sets an event's text color just like the calendar-wide eventTextColor option.
    * @var [type]
    */
   public $textColor;
-  
+
   /**
    * the unique resource for the event
    */
   public $resourceId;
 
+  /**
+  * Sets an event's non-standard fields. FullCalendar will not modify or delete
+  * these fields. For example, developers often include a description field for
+  * use in callbacks such as eventRender.
+  *
+  * @since 2017.01.18
+  * @author @markebjones
+  * @see https://fullcalendar.io/docs/event_data/Event_Object/
+  */
+  public $nonstandard;
+
   public function rules()
   {
     return [
       [['id', 'resourceId'], 'integer'],
-      ['title, allDay, start, end, url, className, source, color, backgroundColor, borderColor, textColor', 'safe'],
+      ['title, allDay, start, end, url, className, source, color, backgroundColor, borderColor, textColor, nonstandard', 'safe'],
       ['editable, startEditable, durationEditable', 'boolean'],
     ];
   }

--- a/yii2fullcalendar.php
+++ b/yii2fullcalendar.php
@@ -28,7 +28,7 @@ class yii2fullcalendar extends elWidget
     public $options = [
         'class' => 'fullcalendar'
     ];
-    
+
     /**
      * @var bool $theme default is true and will render the jui theme for the calendar
      */
@@ -41,9 +41,9 @@ class yii2fullcalendar extends elWidget
         'weekends' => true,
         'editable' => false,
     ];
-	
+
     /**
-     * @var string defaultView will define which view renderer will initially be used for displaying calendar events 
+     * @var string defaultView will define which view renderer will initially be used for displaying calendar events
      */
     public $defaultView = 'month';
 
@@ -60,7 +60,7 @@ class yii2fullcalendar extends elWidget
      */
     public $header = [
         'center'=>'title',
-        'left'=>'prev,next today',        
+        'left'=>'prev,next today',
         'right'=>'month,agendaWeek'
     ];
 
@@ -69,7 +69,7 @@ class yii2fullcalendar extends elWidget
      * @var url to json service
      */
     public $ajaxEvents = NULL;
-    
+
     /**
      * wheather the events will be "sticky" on pagination or not. Uncomment if you are loading events
 	 * separately from the initial options.
@@ -112,12 +112,12 @@ class yii2fullcalendar extends elWidget
      * @var string the javascript code that implements the eventAfterAllRender function
      */
     public $eventAfterAllRender = "";
-	
+
      /**
      * The javascript function to us as en eventDrop callback
      * @var string the javascript code that implements the eventDrop function
      */
-    
+
     public $eventDrop = "";
 
     /**
@@ -154,13 +154,13 @@ class yii2fullcalendar extends elWidget
      * Renders the widget.
      */
     public function run()
-    {   
+    {
         $this->options['data-plugin-name'] = $this->_pluginName;
 
         if (!isset($this->options['class'])) {
             $this->options['class'] = 'fullcalendar';
         }
-        
+
         echo Html::beginTag('div', $this->options) . "\n";
             echo Html::beginTag('div',['class'=>'fc-loading','style' => 'display:none;']);
                 echo Html::encode($this->loading);
@@ -173,7 +173,7 @@ class yii2fullcalendar extends elWidget
     * Registers the FullCalendar javascript assets and builds the requiered js  for the widget and the related events
     */
     protected function registerPlugin()
-    {        
+    {
         $id = $this->options['id'];
         $view = $this->getView();
 
@@ -186,12 +186,12 @@ class yii2fullcalendar extends elWidget
             ThemeAsset::register($view);
         }
 
-        if (isset($this->options['lang'])) 
+        if (isset($this->options['lang']))
         {
             $assets->language = $this->options['lang'];
-        }        
-        
-        if ($this->googleCalendar) 
+        }
+
+        if ($this->googleCalendar)
         {
             $assets->googleCalendar = $this->googleCalendar;
         }
@@ -208,12 +208,12 @@ class yii2fullcalendar extends elWidget
         } else {
             $this->clientOptions['header'] = $this->header;
         }
-		
+
 	if(isset($this->defaultView) && !isset($this->clientOptions['defaultView']))
         {
             $this->clientOptions['defaultView'] = $this->defaultView;
         }
-	
+
 	// clear existing calendar display before rendering new fullcalendar instance
 	// this step is important when using the fullcalendar widget with pjax
 	$js[] = "var loading_container = jQuery('#$id .fc-loading');"; // take backup of loading container
@@ -236,7 +236,7 @@ class yii2fullcalendar extends elWidget
         *    }
         * }
 	*/
-        
+
         $view->registerJs(implode("\n", $js),View::POS_READY);
     }
 
@@ -258,7 +258,7 @@ class yii2fullcalendar extends elWidget
         if ($this->eventAfterAllRender){
             $options['eventAfterAllRender'] = new JsExpression($this->eventAfterAllRender);
         }
-	    
+
         if ($this->eventDrop){
             $options['eventDrop'] = new JsExpression($this->eventDrop);
         }


### PR DESCRIPTION
In addition to the standard FullCalendar fields such as `start`, `end`, and `color`, FullCalendar also supports non-standard fields that you may also include in each [Event Object](https://fullcalendar.io/docs/event_data/Event_Object/). FullCalendar will not modify or delete these fields. For example, developers often include a `description` field for use in callbacks such as `eventRender`.