### PR TITLE
Add "onLoading" event

### DIFF
--- a/yii2fullcalendar.php
+++ b/yii2fullcalendar.php
@@ -272,9 +272,13 @@ class yii2fullcalendar extends elWidget
     {
         $id = $this->options['id'];
       
-        $options['loading'] = new JsExpression("function(isLoading, view ) {
+	if ($this->onLoading)
+            $options['loading'] = new JsExpression($this->onLoading);
+        else {
+	    $options['loading'] = new JsExpression("function(isLoading, view ) {
                 jQuery('#{$id}').find('.fc-loading').toggle(isLoading);
-        }");
+	    }");
+	}
                                                
         //add new theme information for the calendar                                       
 		$options['themeSystem'] = $this->themeSystem;


### PR DESCRIPTION
Since FullCalendar has a loading callback, I would like to take advantage and write my own js code to show a loading indicator over the calendar instead of just providing text to show when events are loading.  The update would provide the new functionality I am looking for, while allowing other users to continue using the loading text below the calendar.