### PR TITLE
fix error message when header is set to false

### DIFF
--- a/yii2fullcalendar.php
+++ b/yii2fullcalendar.php
@@ -238,7 +238,7 @@ class yii2fullcalendar extends elWidget
             $this->clientOptions['contentHeight'] = $this->contentHeight;
         }
 
-        if(is_array($this->header) && isset($this->clientOptions['header']))
+        if(is_array($this->header) && isset($this->clientOptions['header']) && is_array($this->clientOptions['header']))
         {
             $this->clientOptions['header'] = array_merge($this->header,$this->clientOptions['header']);
         } else {


### PR DESCRIPTION
This fixes an error message when the header in clientOptions is set to false in order to hide the header